### PR TITLE
Crosshair fix

### DIFF
--- a/src/cubyz/gui/MenuGUI.java
+++ b/src/cubyz/gui/MenuGUI.java
@@ -7,6 +7,7 @@ import cubyz.world.items.Inventory;
 public abstract class MenuGUI implements RegistryElement {
 	
 	protected float alphaMultiplier;
+	protected boolean renderCrosshair = true;
 	
 	protected final Resource id;
 	
@@ -27,12 +28,19 @@ public abstract class MenuGUI implements RegistryElement {
 	public boolean ungrabsMouse() {
 		return true;
 	}
-	
+
+	public boolean renderCrossHair(){
+		return renderCrosshair;
+	}
+
+	public void setRenderCrosshair(boolean value){
+		renderCrosshair = value;
+	}
+
 	/**
 	 * Is guaranteed to be called when this GUI is closed.
 	 */
 	public void close() {}
-	
 	// For those guis that count on a block inventory. Others can safely ignore this.
 	public void setInventory(Inventory inv) {}
 
@@ -40,5 +48,4 @@ public abstract class MenuGUI implements RegistryElement {
 	public Resource getRegistryID() {
 		return id;
 	}
-	
 }

--- a/src/cubyz/gui/game/GameOverlay.java
+++ b/src/cubyz/gui/game/GameOverlay.java
@@ -68,7 +68,9 @@ public class GameOverlay extends MenuGUI {
 	@Override
 	public void render() {
 		Graphics.setColor(0xFFFFFF);
-		Graphics.drawImage(crosshair, Window.getWidth()/2 - 8 * GUI_SCALE, Window.getHeight()/2 - 8 * GUI_SCALE, 16 * GUI_SCALE, 16 * GUI_SCALE);
+		if (Cubyz.gameUI.getMenuGUI() == null || Cubyz.gameUI.getMenuGUI().renderCrossHair()) {
+			Graphics.drawImage(crosshair, Window.getWidth()/2 - 8 * GUI_SCALE, Window.getHeight()/2 - 8 * GUI_SCALE, 16 * GUI_SCALE, 16 * GUI_SCALE);
+		}
 		if (!(Cubyz.gameUI.getMenuGUI() instanceof GeneralInventory)) {
 			Graphics.drawImage(selection, Window.getWidth()/2 - 79 * GUI_SCALE + Cubyz.inventorySelection*20 * GUI_SCALE, Window.getHeight() - 19 * GUI_SCALE, 18 * GUI_SCALE, 18 * GUI_SCALE);
 			for(int i = 0; i < 8; i++) {

--- a/src/cubyz/gui/game/PauseGUI.java
+++ b/src/cubyz/gui/game/PauseGUI.java
@@ -64,6 +64,7 @@ public class PauseGUI extends MenuGUI {
 		});
 
 		updateGUIScale();
+		setRenderCrosshair(false);
 	}
 
 	@Override

--- a/src/cubyz/gui/game/inventory/GeneralInventory.java
+++ b/src/cubyz/gui/game/inventory/GeneralInventory.java
@@ -51,6 +51,7 @@ public abstract class GeneralInventory extends MenuGUI {
 		num = new Label();
 		num.setTextAlign(Component.ALIGN_CENTER);
 		positionSlots();
+		setRenderCrosshair(false);
 	}
 
 	@Override


### PR DESCRIPTION
## Done:

- Allowed instances of `MenuGUI` to disable the crosshair by calling `MenuGUI:setRenderCrosshair(false)`.

![image](https://user-images.githubusercontent.com/52864251/147033094-98d59cc1-f8e5-47a9-99ef-39787db79195.png)
![image](https://user-images.githubusercontent.com/52864251/147033114-6b7c400f-f6db-4108-8261-a8fdbc272701.png)